### PR TITLE
Add missing libffi build input for ctypes.

### DIFF
--- a/src/overlays/ocaml.nix
+++ b/src/overlays/ocaml.nix
@@ -77,6 +77,7 @@ in lib.optionalAttrs (prev ? ocamlfind-secondary) {
       opam__ctypes_foreign__installed = "true";
       nativeBuildInputs = oa.nativeBuildInputs
         ++ prev.ctypes-foreign.nativeBuildInputs;
+      buildInputs = oa.buildInputs ++ [ final.nixpkgs.libffi ];
     })
   else
     prev.ctypes;


### PR DESCRIPTION
Currently building projects that depend on ctypes fails with:

```
error: builder for '/nix/store/i3yfzr5s7m2vwaf6mdfbg8vj51rfb83m-ctypes-0.20.0.drv' failed with exit code 2;
       last 10 log lines:
       > The following required C libraries are missing: libffi.
       > Please install them and retry. If they are installed in a non-standard location
       > or need special flags, set the environment variables <LIB>_CFLAGS and <LIB>_LIBS
       > accordingly and retry.
       >
       >  For example, if libffi is installed in /opt/local, you can type:
       >
       >    export LIBFFI_CFLAGS=-I/opt/local/include
       >    export LIBFFI_LIBS="-L/opt/local/lib -lffi"
       > make: *** [Makefile:195: test-libffi] Error 1
       For full logs, run 'nix log /nix/store/i3yfzr5s7m2vwaf6mdfbg8vj51rfb83m-ctypes-0.20.0.drv'.
error: 1 dependencies of derivation '/nix/store/ng35m4qysl1yjqgxjsi8yrz6f5r0wv73-pg_query-0.9.7.drv' failed to build
error: 1 dependencies of derivation '/nix/store/rfrl2hzpldc3d22mbqj3mwjh39j3mz8v-ppx_rapper-3.0.0.drv' failed to build
```

Adding `libffi` as a `buildInputs` dependency solves this.

As a side note, I must add that I do not understand how dependencies like `libffi` are supposed to be propagated to packages that use them, like `ctypes`. The reason I mention this is because the `ssl` package compiles just fine finding the correct `openssl` implementation provided by nix without any patches.