### PR TITLE
Fix title `buildOpamProject'` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Building a statically linked library or binary from a local directory:
 ```
 
 </div>
+
 ### `buildOpamProject'`
 
 ```


### PR DESCRIPTION
GitHub Markdown does not pickup `###` as starting a title if there is no empty line before.

Before:
![image](https://user-images.githubusercontent.com/5920602/168280944-c4ffae4b-be34-4dd5-8aea-2f5503a8507e.png)

After:
![image](https://user-images.githubusercontent.com/5920602/168281055-d092a1f4-f2f0-4f91-8e88-13d6283f5a83.png)
