### PR TITLE
`opam monorepo` support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,6 +63,22 @@
         "type": "github"
       }
     },
+    "opam-overlays": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654162756,
+        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "type": "github"
+      }
+    },
     "opam-repository": {
       "flake": false,
       "locked": {
@@ -102,6 +118,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "opam-overlays": "opam-overlays",
         "opam-repository": "opam-repository",
         "opam2json": "opam2json"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,10 +14,21 @@
       url = "github:ocaml/opam-repository";
       flake = false;
     };
+
+    # used for opam-monorepo
+    opam-overlays = {
+      url = "github:dune-universe/opam-overlays";
+      flake = false;
+    };
+    mirage-opam-overlays = {
+      url = "github:dune-universe/mirage-opam-overlays";
+      flake = false;
+    };
   };
 
   outputs =
-    { self, nixpkgs, flake-utils, opam2json, opam-repository, ... }@inputs:
+    { self, nixpkgs, flake-utils, opam2json, opam-repository, opam-overlays,
+      mirage-opam-overlays, ... }@inputs:
     {
       aux = import ./src/lib.nix nixpkgs.lib;
       templates.simple = {
@@ -46,7 +57,7 @@
             opam2json.overlay
             opam-overlay
           ]);
-        opam-nix = import ./src/opam.nix { inherit pkgs opam-repository; };
+        opam-nix = import ./src/opam.nix { inherit pkgs opam-repository opam-overlays mirage-opam-overlays; };
       in rec {
         lib = opam-nix;
         checks = packages


### PR DESCRIPTION
This PR adds support for [opam-monorepo](https://github.com/tarides/opam-monorepo).

To support building [mirage](https://mirage.io/) unikernels for cross-compilation targets we need to build them with dune since [mirage 4](https://mirage.io/docs/mirage-4) (in the absence of ocaml/opam cross compilation support).

Dune supports cross compilation with 'build contexts' using a toolchain which will use a target compiler installed in `<opam-switch>/default/<toolchain>` (as opposed to the host compiler). But not all dependencies are build with the target compiler. Notably ppx requires building with the host compiler. This information in stored in dune files -- e.g. [here](https://github.com/mirage/mirage-tcpip/blob/3ab30ab7b43dede75abf7b37838e051e0ddbb23a/src/tcp/dune#L9). In order to statically know how to build dependencies, we would have to parse the dune files to try and find out (which is non-trivial). Potentially a better solution is to encode the dependency build contexts in `opam` files, but opam [doesn't currently support cross-compilation](https://github.com/ocaml/opam/issues/1536). 

Instead, `opam-monorep` is used to build mirage unikernels. This fetches all the dependencies (filtered with `?monorepo` in the opam file)  to a local directory `duniverse`. Dune then builds the whole project. Unfortunately we can't benefit from the dune cache in our nix derivation, so all the dependencies will be rebuilt on every nix build.

This is implemented in the [opam-monorepo](https://github.com/tarides/opam-monorepo) project. This PR adds support for this workflow in the for of the `queryToScopeMonorepo` function, along with the lower layer functions `mkSrcsScope`, `deduplicateSrcs`, and `defsToSrcs`. We refactor the source fetching logic into `evaluator/default.nix` to share it between `mkSrc` (a derivation fetching a package's source) and `builder`.

To see an example of this usage see [https://github.com/RyanGibb/mirage-hello](https://github.com/RyanGibb/mirage-hello). A flake template is the works.