### PR TITLE
update `buildDuneProject` docs with dune 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Build a package from a local directory:
 
 A convenience wrapper around `buildOpamProject`. Behaves exactly as
 `buildOpamProject`, except runs `dune build ${name}.opam` in an
-environment with `dune_2` and `ocaml` from nixpkgs beforehand. This is
+environment with `dune_3` and `ocaml` from nixpkgs beforehand. This is
 supposed to be used with dune's `generate_opam_files`
 
 #### Examples


### PR DESCRIPTION
Small document update after I noticed dune 3 was [used](https://github.com/tweag/opam-nix/commit/a479ca027e9b28f595e4ed08f06c8ee56b96588a) in `buildDuneProject`.