### PR TITLE
joinRepos: symlink entire package versions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,18 +33,21 @@
       overlays = {
         ocaml-overlay = import ./src/overlays/ocaml.nix;
         ocaml-static-overlay = import ./src/overlays/ocaml-static.nix;
+        default = final: prev: {
+          opam = prev.opam.overrideAttrs (oa: {
+            patches = oa.patches or [ ] ++ [ ./patches/opam.patch ];
+          });
+          lndir-level = prev.xorg.lndir.overrideAttrs (oa: {
+            patches = oa.patches or [ ] ++ [ ./patches/lndir-level.patch ];
+          });
+        };
       };
     } // flake-utils.lib.eachDefaultSystem (system:
       let
-        opam-overlay = self: super: {
-          opam = super.opam.overrideAttrs (oa: {
-            patches = oa.patches or [ ] ++ [ ./patches/opam.patch ];
-          });
-        };
         pkgs = nixpkgs.legacyPackages.${system}.extend
           (nixpkgs.lib.composeManyExtensions [
             opam2json.overlay
-            opam-overlay
+            self.overlays.default
           ]);
         opam-nix = import ./src/opam.nix { inherit pkgs opam-repository; };
       in rec {

--- a/patches/lndir-level.patch
+++ b/patches/lndir-level.patch
@@ -1,0 +1,80 @@
+diff --git a/lndir.c b/lndir.c
+index 6a8d950..6381e93 100644
+--- a/lndir.c
++++ b/lndir.c
+@@ -139,6 +139,7 @@ dodir (const char *fn,		/* name of "from" directory, either absolute or
+ 				   relative to cwd */
+        struct stat *fs, 
+        struct stat *ts,		/* stats for the "from" directory and cwd */
++       int level,		/* the level at which to stop symlinking recursively and symlink entire directories */
+        int rel)			/* if true, prepend "../" to fn before using */
+ {
+     DIR *df;
+@@ -185,7 +186,11 @@ dodir (const char *fn,		/* name of "from" directory, either absolute or
+ #endif
+ 	strcpy (p, dp->d_name);
+ 
+-	if (n_dirs > 0) {
++	if (dp->d_name[0] == '.' &&
++	    (dp->d_name[1] == '\0' || (dp->d_name[1] == '.' &&
++				       dp->d_name[2] == '\0')))
++	    continue;
++	if (level > 0 && n_dirs > 0) {
+ 	    if (lstat (buf, &sb) < 0) {
+ 		mperror (buf);
+ 		continue;
+@@ -195,10 +200,6 @@ dodir (const char *fn,		/* name of "from" directory, either absolute or
+ 	    {
+ 		/* directory */
+ 		n_dirs--;
+-		if (dp->d_name[0] == '.' &&
+-		    (dp->d_name[1] == '\0' || (dp->d_name[1] == '.' &&
+-					       dp->d_name[2] == '\0')))
+-		    continue;
+ 		if (!with_revinfo) {
+ 		    if (!strcmp (dp->d_name, ".git"))
+ 			continue;
+@@ -240,7 +241,7 @@ dodir (const char *fn,		/* name of "from" directory, either absolute or
+ 		    curdir = rcurdir = ocurdir;
+ 		    continue;
+ 		}
+-		dodir (buf, &sb, &sc, (buf[0] != '/'));
++		dodir (buf, &sb, &sc, level - 1, (buf[0] != '/'));
+ 		if (chdir ("..") < 0)
+ 		    quiterr (1, "..");
+ 		curdir = rcurdir = ocurdir;
+@@ -329,6 +330,7 @@ int
+ main (int argc, char *argv[])
+ {
+     char *prog_name = argv[0];
++	int level = -1;	/* -level */
+     const char *fn, *tn;
+     struct stat fs, ts;
+ 
+@@ -339,6 +341,10 @@ main (int argc, char *argv[])
+ 	    ignore_links = 1;
+ 	else if (strcmp(*argv, "-withrevinfo") == 0)
+ 	    with_revinfo = 1;
++    else if (strcmp(*argv, "-level") == 0) {
++        ++argv; --argc;
++        level = atoi(*argv);
++    }
+ 	else if (strcmp(*argv, "--") == 0) {
+ 	    ++argv, --argc;
+ 	    break;
+@@ -349,7 +355,7 @@ main (int argc, char *argv[])
+ 
+     if (argc < 1 || argc > 2)
+ 	quit (1,
+-	      "usage: %s [-silent] [-ignorelinks] [-withrevinfo] fromdir [todir]",
++	      "usage: %s [-silent] [-ignorelinks] [-withrevinfo] [-level <level>] fromdir [todir]",
+ 	      prog_name);
+ 
+     fn = argv[0];
+@@ -372,5 +378,5 @@ main (int argc, char *argv[])
+     if (!(S_ISDIR(fs.st_mode)))
+ 	quit (2, "%s: Not a directory", fn);
+ 
+-    exit (dodir (fn, &fs, &ts, 0));
++    exit (dodir (fn, &fs, &ts, level, 0));
+ }


### PR DESCRIPTION
Fixes a corner-case in & slightly speeds `joinRepos`, at the cost of a hacky patch and a rebuild of a small package. Also useful in context of #18 .