### PR TITLE
Flake: Remove an unecessary dependency on nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    opam2json.url = "github:tweag/opam2json";
+    opam2json = {
+      url = "github:tweag/opam2json";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     flake-compat = {
       url = "github:edolstra/flake-compat";


### PR DESCRIPTION
Make opam2json follow the same version of nixpkgs.