### PR TITLE
Add `xvfb` to the list of external dependencies

### DIFF
--- a/src/overlays/external/debian.nix
+++ b/src/overlays/external/debian.nix
@@ -37,6 +37,7 @@ let
       fontconfig.dev
     ];
   };
+
   # Please keep this list sorted alphabetically and one-line-per-package
 in pkgs // {
   "autoconf" = pkgsBuildBuild.autoconf;
@@ -76,5 +77,6 @@ in pkgs // {
   "ncurses-dev" = ncurses.dev;
   "perl" = pkgsBuildBuild.perl;
   "pkg-config" = pkgsBuildBuild.pkg-config;
+  "xvfb" = xvfb-run;
   "zlib1g-dev" = zlib.dev;
 }


### PR DESCRIPTION
Map the Debian package for [`xvfb` (virtual framebuffer X server)](https://www.x.org/releases/X11R7.6/doc/man/man1/Xvfb.1.xhtml) to the nixpkgs one.

Note that there exists both `xvfb-run` and `xvfb_run` in nixpkgs, but [the latter is only an alias for the former](https://github.com/NixOS/nixpkgs/blob/82b202d382b41451485e5ceca1b6bf29648b5495/pkgs/top-level/aliases.nix#L1609).
