### PR TITLE
Fix executable template use of `buildOpamProject'`

### DIFF
--- a/templates/executable/flake.nix
+++ b/templates/executable/flake.nix
@@ -25,7 +25,7 @@
           ## - or force ocamlfind to be a certain version:
           # ocamlfind = "1.9.2";
         };
-        scope = on.buildOpamProject' { } package ./. query;
+        scope = on.buildOpamProject' { } ./. query;
         overlay = final: prev: {
           # You can add overrides here
           ${package} = prev.${package}.overrideAttrs (_: {


### PR DESCRIPTION
It's currently passing `package` the first parameter as the `name` required for the `buildOpamProject` function.

This error was introduced in 5486c74