### PR TITLE
Patch for findlib 1.9.6

### DIFF
--- a/patches/ocamlfind/install_topfind_196.patch
+++ b/patches/ocamlfind/install_topfind_196.patch
@@ -1,0 +1,14 @@
+diff --git a/src/findlib/Makefile b/src/findlib/Makefile
+index 69a19d1..4ea250c 100644
+--- a/src/findlib/Makefile
++++ b/src/findlib/Makefile
+@@ -123,8 +123,7 @@ clean:
+ install: all
+ 	$(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAML_SITELIB)/$(NAME)"
+ 	$(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAMLFIND_BIN)"
+-	test $(INSTALL_TOPFIND) -eq 0 || $(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAML_CORE_STDLIB)"
+-	test $(INSTALL_TOPFIND) -eq 0 || $(INSTALLFILE) topfind "$(DESTDIR)$(prefix)$(OCAML_CORE_STDLIB)/"
++	test $(INSTALL_TOPFIND) -eq 0 || $(INSTALLFILE) topfind "$(DESTDIR)$(prefix)$(OCAML_SITELIB)/"
+ 	files=`$(SH) $(TOP)/tools/collect_files $(TOP)/Makefile.config \
+ 	findlib.cmi findlib.mli findlib.cma findlib.cmxa findlib$(LIB_SUFFIX) findlib.cmxs \
+ 	findlib_config.cmi findlib_config.ml topfind.cmi topfind.mli \

--- a/src/overlays/ocaml.nix
+++ b/src/overlays/ocaml.nix
@@ -66,8 +66,10 @@ let
         ../../patches/ocamlfind/install_topfind_192.patch
         ++ lib.optional (oa.version == "1.9.3")
         ../../patches/ocamlfind/install_topfind_193.patch
-        ++ lib.optional (lib.versionAtLeast oa.version "1.9.4")
-        ../../patches/ocamlfind/install_topfind_194.patch;
+        ++ lib.optional (lib.versionAtLeast oa.version "1.9.4" && lib.versionOlder oa.version "1.9.6")
+        ../../patches/ocamlfind/install_topfind_194.patch
+        ++ lib.optional (lib.versionAtLeast oa.version "1.9.6")
+        ../../patches/ocamlfind/install_topfind_196.patch;
       opam__ocaml__preinstalled = "false"; # Install topfind
     };
 


### PR DESCRIPTION
Note: findlib 1.9.6 is not in the pinned opam-repository.

Fixes #40