### PR TITLE
fix generation of man directories

### DIFF
--- a/src/builder.nix
+++ b/src/builder.nix
@@ -314,7 +314,7 @@ resolveEnv: rec {
         installPhase = ''
           runHook preInstall
           # Some installers expect the installation directories to be present
-          mkdir -p "$OCAMLFIND_DESTDIR" "$OCAMLFIND_DESTDIR/stublibs" "$out/bin" "$out/share/man/man{1,2,3,4,5,7,8,9}"
+          mkdir -p "$OCAMLFIND_DESTDIR" "$OCAMLFIND_DESTDIR/stublibs" "$out/bin" "$out/share/man/man"{1,2,3,4,5,6,7,8,9}
           ${filterSectionInShell pkgdef'.install or [ ]}
           if [[ -e "''${pname}.install" ]]; then
           ${opam-installer}/bin/opam-installer "''${pname}.install" --prefix="$out" --libdir="$OCAMLFIND_DESTDIR"


### PR DESCRIPTION
When inspecting the output of a locally-built opam package, I noticed that the shell expansion used to create the `man` directories wasn't working as expected, so I updated the builder to fix the issue.

Before:
```
$ tree ./result/share/
./result/share/
└── man
    └── man{1,2,3,4,5,7,8,9}

3 directories, 0 files
```

After:
```
$ tree ./result/share/
./result/share/
└── man
    ├── man1
    ├── man2
    ├── man3
    ├── man4
    ├── man5
    ├── man6
    ├── man7
    ├── man8
    └── man9

11 directories, 0 files
```
