### PR TITLE
fix: report aarch64-darwin as arch = arm64

### DIFF
--- a/src/global-variables.nix
+++ b/src/global-variables.nix
@@ -3,7 +3,11 @@ hostPlatform: {
   root = "/tmp/opam";
   jobs = "$NIX_BUILD_CORES";
   make = "make";
-  arch = hostPlatform.uname.processor;
+  arch =
+    if hostPlatform.isDarwin && hostPlatform.uname.processor == "aarch64" then
+      "arm64"
+    else
+      hostPlatform.uname.processor;
   os = if hostPlatform.isDarwin then
     "macos"
   else if hostPlatform.isLinux then


### PR DESCRIPTION
On `aarch64-darwin`, `opam` sets the `arch` var as `arm64`, rather than `aarch64`:

```
$ opam var | grep arch
arch              arm64                               # Inferred from system
```

This change causes `opam-nix` to match regular `opam`.

In particular, without this fix, we accidentally pick up [`ocaml-option-bytecode-only`](https://opam.ocaml.org/packages/ocaml-option-bytecode-only/) (via the `arch != "arm64"` contstraint) for `ocaml-base-compiler` `5.1.0`, which conflicts with various other packages.