### PR TITLE
add various postgresqls to homebrew overlay

### DIFF
--- a/src/overlays/external/homebrew.nix
+++ b/src/overlays/external/homebrew.nix
@@ -22,6 +22,10 @@ in pkgs // {
   "gtk+3" = gtk3.dev;
   "gtksourceview3" = gtksourceview3.dev;
   "libxml2" = libxml2.dev;
+  "postgresql" = postgresql;
+  "postgresql@14" = postgresql_14;
+  "postgresql@15" = postgresql_15;
+  "postgresql@16" = postgresql_16;
   "proctools" = procps;
   "rust" = rust';
   "zlib" = zlib.dev;


### PR DESCRIPTION
Add some postgresql mappings  to the homebrew overlay - I specifically ran into `postgresql@15` for [conf-postgresql](https://github.com/ocaml/opam-repository/blob/master/packages/conf-postgresql/conf-postgresql.1/opam#L27), but I don't think adding the others will do any harm?