### PR TITLE
support filesystem paths as pin-depends URLs

### DIFF
--- a/src/opam.nix
+++ b/src/opam.nix
@@ -404,7 +404,7 @@ in rec {
       latestVersions = mapAttrs (_: last) (listRepo repo);
 
       pinDeps =
-        getPinDepends repo.passthru.pkgdefs.${name}.${latestVersions.${name}};
+        getPinDepends repo.passthru.pkgdefs.${name}.${latestVersions.${name}} project;
     in materialize {
       repos = [ repo ] ++ optionals pinDepends pinDeps ++ repos;
       resolveArgs = { dev = true; } // resolveArgs;
@@ -419,7 +419,7 @@ in rec {
       latestVersions = mapAttrs (_: last) (listRepo repo);
 
       pinDeps = concatLists (attrValues (mapAttrs
-        (name: version: getPinDepends repo.passthru.pkgdefs.${name}.${version})
+        (name: version: getPinDepends repo.passthru.pkgdefs.${name}.${version} project)
         latestVersions));
     in materialize {
       repos = [ repo ] ++ optionals pinDepends pinDeps ++ repos;
@@ -472,13 +472,13 @@ in rec {
       (applyChecksDocs resolveArgs (opamListToQuery installedList))
     ];
 
-  getPinDepends = pkgdef:
+  getPinDepends = pkgdef: project:
     if pkgdef ? pin-depends then
       map (dep:
         let
           inherit (splitNameVer (head dep)) name version;
         in
-          filterOpamRepo { ${name} = version; } (makeOpamRepo (fetchImpure (last dep)))) pkgdef.pin-depends
+          filterOpamRepo { ${name} = version; } (makeOpamRepo (fetchImpure (last dep) project))) pkgdef.pin-depends
     else
       [ ];
 
@@ -491,7 +491,7 @@ in rec {
       latestVersions = mapAttrs (_: last) (listRepo repo);
 
       pinDeps =
-        getPinDepends repo.passthru.pkgdefs.${name}.${latestVersions.${name}};
+        getPinDepends repo.passthru.pkgdefs.${name}.${latestVersions.${name}} project;
     in queryToScope {
       repos = [ repo ] ++ optionals pinDepends pinDeps ++ repos;
       overlays = overlays;
@@ -508,7 +508,7 @@ in rec {
       latestVersions = mapAttrs (_: last) (listRepo repo);
 
       pinDeps = concatLists (attrValues (mapAttrs
-        (name: version: getPinDepends repo.passthru.pkgdefs.${name}.${version})
+        (name: version: getPinDepends repo.passthru.pkgdefs.${name}.${version} project)
         latestVersions));
     in queryToScope {
       repos = [ repo ] ++ optionals pinDepends pinDeps ++ repos;
@@ -630,7 +630,7 @@ in rec {
       latestVersions = mapAttrs (_: last) (listRepo repo);
 
       pinDeps = concatLists (attrValues (mapAttrs
-        (name: version: getPinDepends repo.passthru.pkgdefs.${name}.${version})
+        (name: version: getPinDepends repo.passthru.pkgdefs.${name}.${version} project)
         latestVersions));
     in queryToMonorepo {
       repos = [ repo ] ++ optionals pinDepends pinDeps ++ repos;


### PR DESCRIPTION
The opam manual [describes](https://opam.ocaml.org/doc/Manual.html#URLs) URLs ([permalink](https://github.com/ocaml/opam/blob/2592c142d1655e93465ba80b44b8952ed6fbb3ee/doc/pages/Manual.md?plain=1#L707C8-L707C8
)) as possibly being a filesystem paths.

This modifies `fetchImpure` to support absolute and relative filesystem paths. To support relative paths the function signature was changed to add the current `project` path.

The monorepo functions don't require this for a relative path, I think, as if the source is already present locally we wouldn't want to vendor it again. So the `getURL` function passes a `null` project which `fetchImpure` checks for and ignores.

The use case is for github.com/ryanGibb/eon having a vendored dependency with a modified opam file with an additional dependency that I want to pick up. This is yet to be pushed, but if it's of interest I can point to it. 

Would you be interested in including something like this upstream?