### PR TITLE
Don't skip empty arguments in build commands

### DIFF
--- a/src/evaluator/default.nix
+++ b/src/evaluator/default.nix
@@ -335,11 +335,9 @@ in rec {
     } else if isList val then {
       type = "command";
       value = if level == 1 then
-        "_ ${
-          concatMapStringsSep " " (part:
-            ''"${toShellString (filterOptionListInShell (level + 1) part)}"'')
-          val
-        }"
+        concatMapStringsSep " " (part:
+          ''"${toShellString (filterOptionListInShell (level + 1) part)}"'')
+        val
       else if level == 0 then
         concatMapStringsSep "\n"
         (part: toCommand (filterOptionListInShell (level + 1) part)) val

--- a/src/evaluator/setup.sh
+++ b/src/evaluator/setup.sh
@@ -9,14 +9,3 @@ compareVersions() {
     else return 1
     fi
 }
-
-# Execute, skipping empty arguments
-_() {
-    args=()
-    for arg in "$@"; do
-        if [ -n "$arg" ]; then
-            args+=("$arg")
-        fi
-    done
-    "${args[@]}"
-}


### PR DESCRIPTION
This is more of a question rather than a real PR. `ocsigenserver` build command contains an empty string argument which is important and fails because of this.

Why is this useful ?