### PR TITLE
Overlay ocsigenserver

### DIFF
--- a/src/overlays/ocaml.nix
+++ b/src/overlays/ocaml.nix
@@ -150,6 +150,18 @@ let
         sed -i 's@/usr/local/include/libfswatch/c@${prev.nixpkgs.fswatch}/include/libfswatch/c@' fswatch/src/dune
       '';
     };
+
+    ocsigenserver = oa: {
+      # The [_] command ignores empty arguments but the build command contains one.
+      buildPhase = ''
+        _() { command "$@"; }
+        ${oa.buildPhase}
+      '';
+      # Ocsigen installs a FIFO.
+      postInstall = ''
+        rm -f "$out"/lib/ocaml/*/site-lib/ocsigenserver/var/run/ocsigenserver_command
+      '';
+    };
   };
 in lib.optionalAttrs (prev ? ocamlfind-secondary) {
   dune = (prev.dune.override { ocaml = final.nixpkgs.ocaml; }).overrideAttrs


### PR DESCRIPTION
The build phase is broken by the `_` function and the install phase installs crazy files that are not allowed by Nix.