### PR TITLE
feat: fake opam list

### DIFF
--- a/src/builder.nix
+++ b/src/builder.nix
@@ -177,6 +177,8 @@ resolveEnv: rec {
         #  -> dune-3.14.2/lib/ocaml/5.1.1/site-lib
         # sed 3. strip '/lib/...' suffix
         #  -> dune-3.14.2
+        # sed 4. replace last occurence of '-' with ' '
+        #  -> dune 3.14.2
         opamList = ''
           opamList() {
             echo "$OCAMLPATH" \
@@ -184,7 +186,9 @@ resolveEnv: rec {
               | sed 's:^/nix/store/[a-z0-9]*-::' \
               | sed 's:/.*$::' \
               | sort \
-              | uniq
+              | uniq \
+              | sed -e 's/\(.*\)-/\1 /' \
+              | column --table
           }
         '';
 


### PR DESCRIPTION
Sometimes it's useful to see what opam packages and versions have been picked by the solver.

This adds a simple implementation for `opam list` which just reads `$OCAMLPATH`.

Note that the output format is different to the real `opam list`, which tabulates the output and includes the package synopsis by default.