### PR TITLE
remove ocamlgraph

### DIFF
--- a/src/overlays/ocaml-static.nix
+++ b/src/overlays/ocaml-static.nix
@@ -65,14 +65,6 @@ let
       '';
     };
 
-    ocamlgraph = oa: {
-      buildPhase = ''
-        ./configure
-        sed 's/graph.cmxs//' -i Makefile
-        make NATIVE_DYNLINK=false
-      '';
-    };
-
     opam-file-format = _: {
       buildPhase = "make opam-file-format.cma opam-file-format.cmxa";
     };


### PR DESCRIPTION
ocamlgraph needs autoconf if we want to use ./configure, and currently fails since autoconf isn't a build input (at least on MacOS). The project now supports building with straight dune:
https://github.com/backtracking/ocamlgraph/blob/master/INSTALL.md

I confirmed this via building an executable that pulls it in, and checked with otool that it didn't link to anything else