### PR TITLE
hostPlatform.arch: treat all aarch64 as arm64

### DIFF
--- a/src/global-variables.nix
+++ b/src/global-variables.nix
@@ -4,7 +4,7 @@ hostPlatform: {
   jobs = "$NIX_BUILD_CORES";
   make = "make";
   arch =
-    if hostPlatform.isDarwin && hostPlatform.uname.processor == "aarch64" then
+    if hostPlatform.uname.processor == "aarch64" then
       "arm64"
     else
       hostPlatform.uname.processor;


### PR DESCRIPTION
If using the nix-darwin `linux-builder` (which is `aarch64-linux`), `isDarwin` is false, but the processor is still `aarch64`, and we want the build arch to be `arm64` in this case too.