### PR TITLE
Add python 3 versions to homebrew package map

### DIFF
--- a/src/overlays/external/homebrew.nix
+++ b/src/overlays/external/homebrew.nix
@@ -27,6 +27,12 @@ in pkgs // {
   "postgresql@15" = postgresql_15;
   "postgresql@16" = postgresql_16;
   "proctools" = procps;
+  "python@3" = python3;
+  "python@3.8" = python38;
+  "python@3.9" = python39;
+  "python@3.10" = python310;
+  "python@3.12" = python312;
+  "python@3.13" = python313;
   "rust" = rust';
   "zlib" = zlib.dev;
 }


### PR DESCRIPTION
These are the versions available in nixpkgs 23.11.

I ran into this trying to install [`conf-python-3`](https://github.com/ocaml/opam-repository/blob/c02a8b3766f5246f228ab0ce0e80991fee77734f/packages/conf-python-3/conf-python-3.9.0.0/opam#L22).