### PR TITLE
convert overrideScope' => overrideScope

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -93,7 +93,7 @@ packages and their versions. A special version of `"*"` means
 ### Scope
 
 ```
-{ overrideScope' = (Scope → Scope → Scope) → Scope
+{ overrideScope = (Scope → Scope → Scope) → Scope
 ; callPackage = (Dependencies → Package) → Dependencies → Package
 ; ${package_name} = package : Package; ... }
 ```
@@ -109,7 +109,7 @@ use packages which aren't in their dependency tree.
 Note that there can only be one version of each package in the set,
 due to constraints in OCaml's way of linking.
 
-`overrideScope'` can be used to apply overlays to the scope, and
+`overrideScope` can be used to apply overlays to the scope, and
 `callPackage` can be used to get `Package`s from the output of
 `opam2nix`, with dependencies supplied from the scope.
 
@@ -232,7 +232,7 @@ let
     opam-file-format = super.opam-file-format.overrideAttrs
       (oa: { opam__ocaml__native = "true"; });
   };
-in (scope.overrideScope' overlay).opam-ed
+in (scope.overrideScope overlay).opam-ed
 ```
 
 </div>
@@ -497,7 +497,7 @@ in scope.callPackage pkg {}
 `Overlay : Scope → Scope → Scope`
 
 Overlays for the `Scope`'s. Contain enough to build the
-examples. Apply with `overrideScope'`.
+examples. Apply with `overrideScope`.
 
 ### Materialization
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1627913399,
-        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -17,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -34,11 +37,11 @@
     "mirage-opam-overlays": {
       "flake": false,
       "locked": {
-        "lastModified": 1661959605,
-        "narHash": "sha256-CPTuhYML3F4J58flfp3ZbMNhkRkVFKmBEYBZY5tnQwA=",
+        "lastModified": 1710922379,
+        "narHash": "sha256-j4QREQDUf8oHOX7qg6wAOupgsNQoYlufxoPrgagD+pY=",
         "owner": "dune-universe",
         "repo": "mirage-opam-overlays",
-        "rev": "05f1c1823d891ce4d8adab91f5db3ac51d86dc0b",
+        "rev": "797cb363df3ff763c43c8fbec5cd44de2878757e",
         "type": "github"
       },
       "original": {
@@ -49,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682362401,
-        "narHash": "sha256-/UMUHtF2CyYNl4b60Z2y4wwTTdIWGKhj9H301EDcT9M=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "884ac294018409e0d1adc0cae185439a44bd6b0b",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {
@@ -66,11 +69,11 @@
     "opam-overlays": {
       "flake": false,
       "locked": {
-        "lastModified": 1654162756,
-        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
+        "lastModified": 1726822209,
+        "narHash": "sha256-bwM18ydNT9fYq91xfn4gmS21q322NYrKwfq0ldG9GYw=",
         "owner": "dune-universe",
         "repo": "opam-overlays",
-        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
+        "rev": "f2bec38beca4aea9e481f2fd3ee319c519124649",
         "type": "github"
       },
       "original": {
@@ -82,11 +85,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1705008664,
-        "narHash": "sha256-TTjTal49QK2U0yVOmw6rJhTGYM7tnj3Kv9DiEEiLt7E=",
+        "lastModified": 1731099738,
+        "narHash": "sha256-cJTrYwJzIW1/bmO4mITWTwbk5IHbFwz/yDypLdy4lc4=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "fa77046c6497f8ca32926acdb7eb1e61777d4c17",
+        "rev": "eecf6d033c6c13a6bda9b445601ddcbaa09dd288",
         "type": "github"
       },
       "original": {
@@ -124,6 +127,21 @@
         "opam-overlays": "opam-overlays",
         "opam-repository": "opam-repository",
         "opam2json": "opam2json"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/src/opam.nix
+++ b/src/opam.nix
@@ -357,12 +357,12 @@ in rec {
   ];
 
   applyOverlays = overlays: scope:
-    scope.overrideScope' (composeManyExtensions overlays);
+    scope.overrideScope (composeManyExtensions overlays);
 
   applyChecksDocs = { with-test ? defaultResolveArgs.with-test
     , with-doc ? defaultResolveArgs.with-doc, ... }:
     query: scope:
-    scope.overrideScope' (_: prev:
+    scope.overrideScope (_: prev:
       mapAttrs (name: _:
         prev.${name}.overrideAttrs (_: {
           doCheck = with-test;

--- a/templates/executable/flake.nix
+++ b/templates/executable/flake.nix
@@ -33,7 +33,7 @@
             doNixSupport = false;
           });
         };
-        scope' = scope.overrideScope' overlay;
+        scope' = scope.overrideScope overlay;
         # The main package containing the executable
         main = scope'.${package};
         # Packages from devPackagesQuery

--- a/templates/multi-package/flake.nix
+++ b/templates/multi-package/flake.nix
@@ -30,7 +30,7 @@
           {
             # You can add overrides here
           };
-        scope' = scope.overrideScope' overlay;
+        scope' = scope.overrideScope overlay;
         # Packages from devPackagesQuery
         devPackages = builtins.attrValues
           (pkgs.lib.getAttrs (builtins.attrNames devPackagesQuery) scope');

--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -18,7 +18,7 @@
             # Your overrides go here
           };
       in {
-        legacyPackages = scope.overrideScope' overlay;
+        legacyPackages = scope.overrideScope overlay;
 
         packages.default = self.legacyPackages.${system}.${package};
       });


### PR DESCRIPTION
After updating this flake's inputs, we start to see:
```
evaluation warning: `overrideScope'` (from `lib.makeScope`) has been renamed to `overrideScope`.
evaluation warning: `overrideScope'` (from `lib.makeScope`) has been renamed to `overrideScope`.
evaluation warning: `overrideScope'` (from `lib.makeScope`) has been renamed to `overrideScope`.
```

This PR updates the flake inputs and changes all uses of `overrideScope'` to `overrideScope`.  

I have tested it with a couple of my projects, and it seems to be working fine.