### PR TITLE
homebrew: add libpq mapping

### DIFF
--- a/src/overlays/external/homebrew.nix
+++ b/src/overlays/external/homebrew.nix
@@ -22,6 +22,7 @@ in pkgs // {
   "gtk+3" = gtk3.dev;
   "gtksourceview3" = gtksourceview3.dev;
   "libxml2" = libxml2.dev;
+  "libpq" = postgresql;
   "postgresql" = postgresql;
   "postgresql@14" = postgresql_14;
   "postgresql@15" = postgresql_15;


### PR DESCRIPTION
Looks like the newer `conf-postgresql` looks for a `libpq` package: https://github.com/ocaml/opam-repository/blob/master/packages/conf-postgresql/conf-postgresql.2/opam#L40, which is made available via the regular `postgresql` package in nixpkgs.