### PR TITLE
Increase priority of avoid-version criteria

### DIFF
--- a/src/opam.nix
+++ b/src/opam.nix
@@ -34,7 +34,7 @@ let
   };
   defaultResolveArgs = {
     env = defaultEnv;
-    criteria = "-count[version-lag,request],-count[version-lag,changed],-count[avoid-version,request]";
+    criteria = "-count[avoid-version,request],-count[version-lag,request],-count[version-lag,changed]";
     depopts = true;
     best-effort = false;
     dev = false;


### PR DESCRIPTION
This addresses #53 by preferring package sets that have fewer "avoided" versions of packages. Typically, pre-release versions and recalled versions have this flag set so that you don't unexpectedly get unstable or known-broken versions of packages.