### PR TITLE
Fix ocamlfind 1.9.8 version check

### DIFF
--- a/src/overlays/ocaml.nix
+++ b/src/overlays/ocaml.nix
@@ -71,7 +71,7 @@ let
         ++ lib.optional (
           lib.versionAtLeast oa.version "1.9.6" && lib.versionOlder oa.version "1.9.8"
         ) ../../patches/ocamlfind/install_topfind_196.patch
-        ++ lib.optional (lib.versionAtLeast "1.9.8" oa.version) ../../patches/ocamlfind/install_topfind_198.patch;
+        ++ lib.optional (lib.versionAtLeast oa.version "1.9.8") ../../patches/ocamlfind/install_topfind_198.patch;
       opam__ocaml__preinstalled = "false"; # Install topfind
     };
 


### PR DESCRIPTION
Fix the argument order for `lib.versionAtLeast` in the version check. This was causing the 1.9.8 patch to be applied for any versions before 1.9.8, failing the builds.