### PR TITLE
Remove references to `apple_sdk.frameworks`

### DIFF
--- a/examples/0install/flake.nix
+++ b/examples/0install/flake.nix
@@ -18,7 +18,7 @@
             ocaml-base-compiler = "*";
           };
         in
-        scope.overrideScope' (
+        scope.overrideScope (
           final: prev: {
             "0install" = prev."0install".overrideAttrs (_: {
               preInstall = "cp _build/default/0install.install .";

--- a/examples/materialized-opam-ed/flake.nix
+++ b/examples/materialized-opam-ed/flake.nix
@@ -17,7 +17,7 @@
           overlay = self: super: { };
 
         in
-        scope.overrideScope' overlay;
+        scope.overrideScope overlay;
 
       defaultPackage = self.legacyPackages.${system}.opam-ed;
 

--- a/examples/opam-ed/flake.nix
+++ b/examples/opam-ed/flake.nix
@@ -25,7 +25,7 @@
             });
           };
         in
-        scope.overrideScope' overlay;
+        scope.overrideScope overlay;
       defaultPackage = self.legacyPackages.${system}.opam-ed;
     });
 }

--- a/examples/tezos/flake.nix
+++ b/examples/tezos/flake.nix
@@ -16,7 +16,7 @@
           scope = queryToScope { } { tezos = "*"; };
           overlay = self: super: { };
         in
-        scope.overrideScope' overlay;
+        scope.overrideScope overlay;
 
       defaultPackage = self.legacyPackages.${system}.tezos;
     });

--- a/src/overlays/ocaml-darwin.nix
+++ b/src/overlays/ocaml-darwin.nix
@@ -28,14 +28,6 @@ let
       installPhase = "mkdir $out";
     };
 
-    dune =
-      oa: with pkgs; {
-        buildInputs = oa.buildInputs ++ [
-          darwin.apple_sdk.frameworks.Foundation
-          darwin.apple_sdk.frameworks.CoreServices
-        ];
-      };
-
     zarith = oa: {
       buildPhase = ''
         ./configure


### PR DESCRIPTION
This addresses the following deprecation warnings:

```
trace: evaluation warning: darwin.apple_sdk_11_0.Foundation: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
trace: evaluation warning: darwin.apple_sdk_11_0.CoreServices: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
```

The `dune` executable seems to continue to work correctly, which I verified by running `dune --help` inside a `nix develop .#_0install` shell. When testing some of the examples I noticed there were some stray usages of `overrideScope'`, so I took the opportunity to update those as well.