### PR TITLE
Update examples to use `default` fields

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -131,7 +131,7 @@ relevant per-platform `lib` is in scope, something like this flake:
   outputs = { self, opam-nix, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       with opam-nix.lib.${system}; {
-        defaultPackage = # <example goes here>
+        packages.default = # <example goes here>
       });
 }
 ```

--- a/examples/0install/flake.nix
+++ b/examples/0install/flake.nix
@@ -28,6 +28,6 @@
           }
         );
 
-      defaultPackage = self.legacyPackages.${system}."0install";
+      packages.default = self.legacyPackages.${system}."0install";
     });
 }

--- a/examples/frama-c/flake.nix
+++ b/examples/frama-c/flake.nix
@@ -41,10 +41,9 @@
               '';
             });
           };
-
         in
         scope.overrideScope overlay;
 
-      defaultPackage = self.legacyPackages.${system}.frama-c;
+      packages.default = self.legacyPackages.${system}.frama-c;
     });
 }

--- a/examples/frama-c/flake.nix
+++ b/examples/frama-c/flake.nix
@@ -32,7 +32,6 @@
               nativeBuildInputs = oa.nativeBuildInputs ++ [ pkgs.makeWrapper ];
 
               NIX_LDFLAGS =
-                with pkgs;
                 "-L${pkgs'.fontconfig.lib}/lib -L${pkgs'.pkgsStatic.expat}/lib -lfontconfig -lfreetype -lexpat";
               postInstall = ''
                 for i in $(find $out/bin -type f); do

--- a/examples/materialized-opam-ed/flake.nix
+++ b/examples/materialized-opam-ed/flake.nix
@@ -15,13 +15,12 @@
           inherit (opam-nix.lib.${system}) materializedDefsToScope;
           scope = materializedDefsToScope { } ./package-defs.json;
           overlay = self: super: { };
-
         in
         scope.overrideScope overlay;
 
-      defaultPackage = self.legacyPackages.${system}.opam-ed;
+      packages.default = self.legacyPackages.${system}.opam-ed;
 
-      devShell =
+      devShells.default =
         with opam-nix.inputs.nixpkgs.legacyPackages.${system};
         mkShell { buildInputs = [ opam-nix.packages.${system}.opam-nix-gen ]; };
     });

--- a/examples/ocaml-lsp/flake.nix
+++ b/examples/ocaml-lsp/flake.nix
@@ -24,6 +24,7 @@
           scope = buildOpamProject' { } src { ocaml-base-compiler = "*"; };
         in
         scope;
-      defaultPackage = self.legacyPackages.${system}.ocaml-lsp-server;
+
+      packages.default = self.legacyPackages.${system}.ocaml-lsp-server;
     });
 }

--- a/examples/opam-ed/flake.nix
+++ b/examples/opam-ed/flake.nix
@@ -26,6 +26,7 @@
           };
         in
         scope.overrideScope overlay;
-      defaultPackage = self.legacyPackages.${system}.opam-ed;
+
+      packages.default = self.legacyPackages.${system}.opam-ed;
     });
 }

--- a/examples/opam2json-static/flake.nix
+++ b/examples/opam2json-static/flake.nix
@@ -25,10 +25,9 @@
               postFixup = "rm -rf $out/nix-support";
             });
           };
-
         in
         scope.overrideScope overlay;
 
-      defaultPackage = self.legacyPackages.${system}.opam2json;
+      packages.default = self.legacyPackages.${system}.opam2json;
     });
 }

--- a/examples/opam2json/flake.nix
+++ b/examples/opam2json/flake.nix
@@ -19,6 +19,7 @@
           };
         in
         scope;
-      defaultPackage = self.legacyPackages.${system}.opam2json;
+
+      packages.default = self.legacyPackages.${system}.opam2json;
     });
 }

--- a/examples/rocq/flake.nix
+++ b/examples/rocq/flake.nix
@@ -40,6 +40,6 @@
         in
         scope;
 
-      defaultPackage = self.legacyPackages.${system}.coq-inf-seq-ext;
+      packages.default = self.legacyPackages.${system}.coq-inf-seq-ext;
     });
 }

--- a/examples/tezos/flake.nix
+++ b/examples/tezos/flake.nix
@@ -10,7 +10,6 @@
     flake-utils.lib.eachDefaultSystem (system: {
       legacyPackages =
         let
-
           inherit (opam-nix.lib.${system}) queryToScope;
 
           scope = queryToScope { } { tezos = "*"; };
@@ -18,6 +17,6 @@
         in
         scope.overrideScope overlay;
 
-      defaultPackage = self.legacyPackages.${system}.tezos;
+      packages.default = self.legacyPackages.${system}.tezos;
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -193,7 +193,7 @@
               ];
             };
           }
-          // builtins.mapAttrs (_: e: e.defaultPackage.${system}) examples;
+          // builtins.mapAttrs (_: e: e.packages.${system}.default) examples;
       }
     );
 }


### PR DESCRIPTION
I noticed that the examples were using the old `defaultPackage` and `devShell` fields. This updates them to the new `package.default` and `devShells.default` fields (see https://github.com/NixOS/nix/issues/5532 for more information), in line with the templates.