### PR TITLE
A few ROCQLIB-related fixes

### DIFF
--- a/src/overlays/ocaml.nix
+++ b/src/overlays/ocaml.nix
@@ -148,8 +148,7 @@ let
           export COQCORELIB="${final.coq-core}/lib/ocaml/${final.ocaml.version}/site-lib/coq-core"
         ''
         + lib.optionalString (prev ? rocq-stdlib) ''
-          export COQLIB="${final.rocq-stdlib}/lib/ocaml/${final.ocaml.version}/site-lib/coq"
-          export COQCORELIB="${final.rocq-core}/lib/ocaml/${final.ocaml.version}/site-lib/coq-core"
+          export ROCQLIB="${final.rocq-stdlib}/lib/ocaml/${final.ocaml.version}/site-lib/coq"
         ''
       );
     };

--- a/src/overlays/ocaml.nix
+++ b/src/overlays/ocaml.nix
@@ -161,7 +161,7 @@ let
           if lib.versionAtLeast oa.version "9.0.0" then
             ''
               mkdir -p $out/nix-support
-              echo "export COQLIB=\"${final.rocq-stdlib}/lib/ocaml/${final.ocaml.version}/site-lib/coq\"" >> $out/nix-support/setup-hook
+              echo "export ROCQLIB=\"${final.rocq-stdlib}/lib/ocaml/${final.ocaml.version}/site-lib/coq\"" >> $out/nix-support/setup-hook
             ''
           else
             ''

--- a/src/overlays/ocaml.nix
+++ b/src/overlays/ocaml.nix
@@ -223,7 +223,7 @@ let
         oa.fixupPhase or ""
         + ''
           mkdir -p $out/nix-support
-          echo "export ROCQLIB=\"$out/lib/ocaml/${final.ocaml.version}/site-lib/coq/theories\"" >> $out/nix-support/setup-hook
+          echo "export ROCQLIB=\"$out/lib/ocaml/${final.ocaml.version}/site-lib/coq\"" >> $out/nix-support/setup-hook
         '';
     };
 


### PR DESCRIPTION
This PR addresses some issues that came up building a small, fairly straightforward Rocq [project](https://github.com/henrytill/bits-rocq) that depends on a few OCaml libraries and a single Rocq library (`coq-menhirlib`, part of `menhir`) using `buildOpamProject`. 

The biggest issue was related to the fact that `roq-core` would set `ROCQLIB` in its `$out/nix-support/setup-hook`, which would be picked up when building `coq-menhirlib`.  On the other hand, `coq-stdlib`'s `setup-hook` would set `COQLIB` and not `ROCQLIB`, the Rocq build tooling preferred `ROCQLIB` to `COQLIB`, so that when both were set, it would ignore the latter, rather than allowing the intended override behavior that would come from `coq-stdlib`'s `setup-hook` running after `rocq-core`'s.  This would cause the `coq-menhirlib` build to fail, as it was unable to find certain parts of the stdlib.  I traced a failing build to discover this:
```
2025-08-02T23:49:48.4597551Z coq-menhirlib> COQLIB=/nix/store/al72ainkhf6wvbvl9f77z6aprcy3nl8b-rocq-stdlib-9.0.0/lib/ocaml/5.3.0/site-lib/coq
2025-08-02T23:49:48.4598957Z coq-menhirlib> ROCQLIB=/nix/store/bysv9yd6bj88g8a6ap34n63s9r00bjdb-rocq-core-9.0.0/lib/ocaml/5.3.0/site-lib/coq
```
If you'd like you can observe the rest of the logs for that build [here](https://github.com/henrytill/bits-rocq/actions/runs/16698935053/job/47266920627).

This problem is fixed by 9fafd026ba7aa9a0553a985c0288a8d308da28c3.

After that dependency problem was addressed, my own project would not find the new separate `Stdlib` as expected, which I fixed with b414744421eaca1fb31b0d7382235ed9db25f20d.  This also has the advantage of making the setting of `ROCQLIB` more consistent for projects using Rocq >= 9.0.0 (or the legacy shims for it).

Along the way towards producing these fixes, I noticed a pathological case where the path contained in `ROCQLIB` had duplicate `theories` components and would cause failures building `coq-menhirlib`, which I fixed in 5a9a2f7703bfc797328325e46804fd10215ffad5.  My guess is that this path component was introduced to provide compatibility after the stdlib was separated and (partially) moved, but in fact it prevents tools from finding the adjacent `user-contrib` directory where a good portion of the newly separated stdlib lives in a `Stdlib` directory.  And similarly, with certain `{coq,rocq}_makefile`-based builds it will end up creating this malformed path.