### PR TITLE
Minimize avoided versions in dependency resolution

### DIFF
--- a/src/opam.nix
+++ b/src/opam.nix
@@ -91,7 +91,7 @@ let
   };
   defaultResolveArgs = {
     env = defaultEnv;
-    criteria = "-count[avoid-version,request],-count[version-lag,request],-count[version-lag,changed]";
+    criteria = "-count[avoid-version,request],-count[avoid-version,changed],-count[version-lag,request],-count[version-lag,changed]";
     depopts = true;
     best-effort = false;
     dev = false;


### PR DESCRIPTION
The changes in #110 prevented selection of avoided versions for packages requested by the query but did not limit the selection of avoided versions to satisfy dependencies. Adding criteria to minimize avoid-version for changed packages keeps any avoided versions from being unnecessarily selected.