### PR TITLE
Add openssl to add libssl for conf-postgresql in overlay

### DIFF
--- a/src/overlays/ocaml.nix
+++ b/src/overlays/ocaml.nix
@@ -289,7 +289,7 @@ let
     };
 
     conf-postgresql = oa: {
-      nativeBuildInputs = oa.nativeBuildInputs ++ [ prev.nixpkgs.openssl ];
+      buildInputs = oa.buildInputs ++ [ prev.nixpkgs.openssl ];
     };
   };
 in

--- a/src/overlays/ocaml.nix
+++ b/src/overlays/ocaml.nix
@@ -287,6 +287,10 @@ let
     alt-ergo-lib = oa: {
       nativeBuildInputs = oa.nativeBuildInputs ++ [ prev.nixpkgs.which ];
     };
+
+    conf-postgresql = oa: {
+      nativeBuildInputs = oa.nativeBuildInputs ++ [ prev.nixpkgs.openssl ];
+    };
   };
 in
 lib.optionalAttrs (prev ? ocamlfind-secondary) {


### PR DESCRIPTION
This PR adds `nixpkgs.openssl` to conf-postgresql buildInputs.

`libpq` provided by nixpkgs is not linked to libssl:

```shell-session
$ pkg-config --print-errors libpq
Package libssl was not found in the pkg-config search path.
Perhaps you should add the directory containing `libssl.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libssl', required by 'libpq', not found
Package 'libcrypto', required by 'libpq', not found
```
