### PR TITLE
install toplevel files

### DIFF
--- a/examples/down/flake.nix
+++ b/examples/down/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "Test for toplevel files installation (down package)";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.opam-nix.url = "github:tweag/opam-nix";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs =
+    {
+      self,
+      nixpkgs,
+      opam-nix,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        scope = opam-nix.lib.${system}.queryToScope { } {
+          ocaml-base-compiler = "*";
+          down = "*";
+        };
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.default = scope.down;
+
+        checks.toplevel-installed = pkgs.runCommand "check-toplevel-installed" { } ''
+          if test -f "${scope.down}/lib/ocaml/${scope.ocaml.version}/site-lib/toplevel/down.top"; then
+            echo "SUCCESS: down.top found in toplevel directory"
+            touch $out
+          else
+            echo "FAILURE: down.top not found"
+            exit 1
+          fi
+        '';
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,19 @@
       in
       rec {
         lib = opam-nix;
-        checks = packages // (pkgs.callPackage ./examples/docfile { inherit opam-nix; }).checks;
+        checks =
+          packages
+          // (pkgs.callPackage ./examples/docfile { inherit opam-nix; }).checks
+          // (
+            let
+              down = (import ./examples/down/flake.nix).outputs {
+                self = down;
+                opam-nix = inputs.self;
+                inherit (inputs) nixpkgs flake-utils;
+              };
+            in
+            down.checks.${system}
+          );
 
         legacyPackages = __mapAttrs (
           name: versions:

--- a/src/builder.nix
+++ b/src/builder.nix
@@ -413,7 +413,7 @@ originalPkgdef: resolveEnv: {
         installPhase = ''
           runHook preInstall
           # Some installers expect the installation directories to be present
-          mkdir -p "$OCAMLFIND_DESTDIR" "$OCAMLFIND_DESTDIR/stublibs" "$out/bin" "$out/share/man/man"{1,2,3,4,5,6,7,8,9}
+          mkdir -p "$OCAMLFIND_DESTDIR" "$OCAMLFIND_DESTDIR/stublibs" "$OCAMLFIND_DESTDIR/toplevel" "$out/bin" "$out/share/man/man"{1,2,3,4,5,6,7,8,9}
           ${filterSectionInShell pkgdef.install or [ ]}
           if [[ -e "''${OPAM_PACKAGE_NAME}.install" ]]; then
           ${opam-installer}/bin/opam-installer "''${OPAM_PACKAGE_NAME}.install" --prefix="$out" --libdir="$OCAMLFIND_DESTDIR"


### PR DESCRIPTION
Packages like [down](https://github.com/dbuenzli/down) include top-level integrations in the form of `*.top` files.  We currently do not install these files, but it seems that's only because we haven't given them a place to be installed.  This PR adds a `toplevel` directory below `$OCAMLFIND_DESTDIR` to allow their installation.

Note that using these in a shell environment still requires exporting an `OCAML_TOPLEVEL_PATH` environment variable (or similar) and ensuring that `topfind` reads it in an `.ocamlinit` file.