### PR TITLE
Use existing `ocamlfind` patches if exist in repository

### DIFF
--- a/src/overlays/ocaml.nix
+++ b/src/overlays/ocaml.nix
@@ -63,7 +63,8 @@ let
 
     ocamlfind = oa: {
       patches =
-        lib.optional (lib.versionOlder oa.version "1.9.3") ../../patches/ocamlfind/install_topfind_192.patch
+        (oa.patches or [ ])
+        ++ lib.optional (lib.versionOlder oa.version "1.9.3") ../../patches/ocamlfind/install_topfind_192.patch
         ++ lib.optional (oa.version == "1.9.3") ../../patches/ocamlfind/install_topfind_193.patch
         ++ lib.optional (
           lib.versionAtLeast oa.version "1.9.4" && lib.versionOlder oa.version "1.9.6"


### PR DESCRIPTION
Change to use existing package patches as the base for `ocamlfind`, as otherwise the ones provided by the repository are completely overridden.

In https://github.com/oxcaml/opam-repository/commit/c66d0c974520485bf987ab4d488118344beda288  `ocamlfind` was added with a patch (unlike the base in [ocaml/opam-repository](https://github.com/ocaml/opam-repository/blob/75005aaa525c00ad1d4f4f8923680923b973a1e4/packages/ocamlfind/ocamlfind.1.9.8/opam)). This patch was necessary and `opam-nix` using this repository, after that revision would fail. This fix allows https://github.com/oxcaml/opam-repository to be used with `opam-nix` again.