### PR TITLE
Remove adwaita-icon-theme depext remapping

### DIFF
--- a/src/overlays/external/debian.nix
+++ b/src/overlays/external/debian.nix
@@ -104,7 +104,6 @@ in
 # Please keep this list sorted alphabetically and one-line-per-package
 pkgs
 // {
-  "adwaita-icon-theme" = gnome.adwaita-icon-theme;
   "autoconf" = pkgsBuildBuild.autoconf;
   "binutils-multiarch" = binutils;
   "cargo" = cargo';


### PR DESCRIPTION
The adwaita-icon-theme package is at nixpkgs toplevel since 2024-06-22 and since 2024-11-21 the alias in gnome throws an error.