### PR TITLE
fix: nested list in `nativeBuildInputs`

### DIFF
--- a/src/builder.nix
+++ b/src/builder.nix
@@ -350,7 +350,7 @@ originalPkgdef: resolveEnv: {
         nativeBuildInputs =
           extInputs
           ++ ocamlInputs
-          ++ optional fa.withFakeOpam [ fake-opam ]
+          ++ optional fa.withFakeOpam fake-opam
           ++ optional (hasSuffix ".zip" archive) unzip
           ++ optional (hasSuffix ".bz2" archive) bz2Unpacker;
 


### PR DESCRIPTION
```
evaluation warning: Dependency of package 'ppx_hegel_test' uses a nested list in attribute 'nativeBuildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
```