### PR TITLE
Interpolate variables in builder with evalOpamVar

### DIFF
--- a/src/evaluator/default.nix
+++ b/src/evaluator/default.nix
@@ -675,7 +675,7 @@ rec {
         type = "string";
         value =
           if length pkgs == 1 then
-            "\${${varToShellVar val.id}}"
+            "$(evalOpamVar ${escapeShellArg val.id})"
           else
             "$(if ${
               concatMapStringsSep " && " (


### PR DESCRIPTION
The previous interpolation processing does not support opam conditional expansions but evalOapmVar does. The build commands for ocaml.5.5.0 use this feature in the build commands so this is necessary for opam-nix to work with ocaml 5.5.0.